### PR TITLE
Fix constructor args and remove stray return

### DIFF
--- a/backend/app/logic/notification_manager.py
+++ b/backend/app/logic/notification_manager.py
@@ -165,5 +165,3 @@ class NotificationManager(BaseManager):
         except Exception as e:
             logger.error(f"Failed to create task expired notification: {e}")
             return None
-
-        return count

--- a/backend/app/logic/pairing_manager.py
+++ b/backend/app/logic/pairing_manager.py
@@ -8,9 +8,9 @@ import time
 
 
 class PairingManager(BaseManager):
-    def __init__(self, db: Depends, user_id: str | None = None):
-        super().__init__(db, user_id)
-        self.notification_manager = NotificationManager(db, user_id)
+    def __init__(self, user_id: str):
+        super().__init__(user_id)
+        self.notification_manager = NotificationManager(user_id)
 
     def _hash_to_code(self, input_str: str) -> str:
         hash_bytes = hashlib.sha256(input_str.encode()).digest()

--- a/backend/app/logic/reward_manager.py
+++ b/backend/app/logic/reward_manager.py
@@ -5,9 +5,9 @@ from app.logic.base_manager import BaseManager
 from app.logic.notification_manager import NotificationManager
 from app.schemas.notification import NotificationCreate
 class RewardManager(BaseManager):
-    def __init__(self, db: Depends, user_id: str | None = None):
-        super().__init__(db, user_id)
-        self.notification_manager = NotificationManager(db, user_id)
+    def __init__(self, user_id: str):
+        super().__init__(user_id)
+        self.notification_manager = NotificationManager(user_id)
 
     async def create_reward(self, reward_data: dict) -> dict:
         user = await self.get_user_or_403(refresh=True)


### PR DESCRIPTION
## Summary
- fix `RewardManager` and `PairingManager` constructors to take only a user id
- remove leftover `return count` from `NotificationManager`

## Testing
- `pytest -q`
- `python -m compileall backend/app/logic`

------
https://chatgpt.com/codex/tasks/task_e_683f7071dfc8832f9398a78a0d3295d9